### PR TITLE
Remove "gla" from the dictionary

### DIFF
--- a/dictionary/en.yaml
+++ b/dictionary/en.yaml
@@ -2073,11 +2073,6 @@ mian:
   gloss: "cat"
   tags: [animal]
   short: "[E:tce* pan] is a cat/felid/member of family Felidae."
-gla:
-  id: kmycfjjnv4
-  family: "R"
-  gloss: "tool"
-  short: "[E:tce* ma] [tool] is used to make [A:()] [purpose] true."
 kali:
   id: egsqs45rsj
   family: "R"


### PR DESCRIPTION
As discussed on Discord, "gla" and "zole" (gbk8uduqqh) are two words for the same thing, we have opted to keep only "zole".