### PR TITLE
🧑‍💻 Redirect dev server URL with trailing slash

### DIFF
--- a/web/src/vite.config.js
+++ b/web/src/vite.config.js
@@ -4,8 +4,7 @@ import { defineConfig } from "vite"
 import ViteYaml from "@modyfi/vite-plugin-yaml";
 
 // Adapted from https://github.com/vitejs/vite/issues/6596#issuecomment-1651355986
-// Note (vite dev): This only changes the request, it does NOT change the url on
-// the browser.
+// Note (vite dev): This plugin adds trailing slash.
 // Note (vite preview): Nothing happens.
 // Note (GitHub Pages): GitHub Pages adds trailing slash itself in the browser.
 //                      https://github.com/slorber/trailing-slash-guide
@@ -15,7 +14,7 @@ const AppendTrailingUrlSlash = () => {
         apply: "serve",
         enforce: "post",
         configureServer(server) {
-            server.middlewares.use((req, _, next) => {
+            server.middlewares.use((req, res, next) => {
                 if (!req.url) {
                     return next();
                 }
@@ -34,7 +33,10 @@ const AppendTrailingUrlSlash = () => {
                     "g",
                 );
                 if (regexp.test(req.url)) {
-                    req.url += "/";
+                    const MOVED_PERMANENTLY = 301;
+                    res.writeHead(MOVED_PERMANENTLY, { Location: req.url + "/" });
+                    res.end();
+                    return;
                 }
                 next();
             });


### PR DESCRIPTION
Examples of redirects:

- `localhost:5173/eberban` -> `localhost:5173/eberban/`
- `localhost:5173/eberban/dictionary` -> `localhost:5173/eberban/dictionary/`

I made this change because I once again encountered URL issues by typing out the URL by hand and forgetting the trailing slash. Now the dev server actually matches GitHub Pages behaviour 😎

So this finishes what I started in
[the massive PR that overhauled the frontend][PR].

[PR]: https://github.com/eberban/eberban/pull/83