### PR TITLE
✅ Pass lexing a single eberban particle

### DIFF
--- a/web/src/scripts/eberban_symbols.ts
+++ b/web/src/scripts/eberban_symbols.ts
@@ -1,4 +1,4 @@
-export const all_sonorants = ["n", "r", "l"];
+export const all_sonorants = ["n", "r", "l"] as const;
 
 export const all_non_sonorants = [
     "m",
@@ -14,9 +14,9 @@ export const all_non_sonorants = [
     "j",
     "k",
     "g",
-];
+] as const;
 
-export const all_vowels = ["i", "e", "a", "o", "u"];
+export const all_vowels = ["i", "e", "a", "o", "u"] as const;
 
 export const all_initial_pairs = [
     "mn",

--- a/web/src/scripts/lexer/combo.ts
+++ b/web/src/scripts/lexer/combo.ts
@@ -1,0 +1,171 @@
+import {
+    Alphabet_char,
+    Consonant,
+    is_consonant,
+    is_sonorant,
+    is_vowel,
+    Vowel,
+    Sonorant as Sonorant_Char,
+} from "./types_and_preds";
+
+
+
+
+interface Combo_Item {
+    readonly type: string;
+    readonly get_content: () => string;
+}
+
+
+
+
+class Sonorant implements Combo_Item {
+    readonly type = "sonorant";
+    private readonly value: Sonorant_Char;
+    constructor(value: Sonorant_Char) {
+        this.value = value;
+    }
+    get_content() {
+        return this.value;
+    }
+}
+
+function build_sonorant(sonorant: Sonorant_Char): Sonorant {
+    return new Sonorant(sonorant);
+}
+
+
+
+
+class Mahul implements Combo_Item {
+    readonly type = "mahul";
+    private readonly value: (Vowel | "h")[] = [];
+    constructor(value: (Vowel | "h")[]) {
+        this.value = value;
+    }
+    get_content() {
+        return this.value.join("");
+    }
+}
+
+function build_mahul(letters: Alphabet_char[]):
+{ mahul: Mahul, unbuilt: Alphabet_char[] }
+{
+    const mahul_letters: (Vowel | "h")[] = [];
+    for (let index = 0; index < letters.length; index++) {
+        const current_letter = letters[index];
+        const next_letter: Alphabet_char | undefined = letters[index + 1];
+        if (is_vowel(current_letter)) {
+            mahul_letters.push(current_letter);
+        }
+        else if (current_letter === "h") {
+            if (is_vowel(next_letter)) {
+                mahul_letters.push(current_letter, next_letter);
+                index++;
+            } else {
+                // todo error handling
+                const mahul = new Mahul(mahul_letters);
+                return { mahul, unbuilt: letters.slice(index) };
+            }
+        } else {
+            // current_letter is a consonant. The mahul is built.
+            const mahul = new Mahul(mahul_letters);
+            return { mahul, unbuilt: letters.slice(index) };
+        }
+    }
+    const mahul = new Mahul(mahul_letters);
+    return { mahul, unbuilt: [] };
+}
+
+
+
+
+type Shyllable_Type = "non-sonorant-shyllable" | "sonorant-shyllable";
+
+class Shyllable implements Combo_Item {
+    readonly type: Shyllable_Type;
+    private readonly consonants: Consonant[];
+    private readonly mahul: Mahul;
+    constructor(type: Shyllable_Type, consonants: Consonant[], mahul: Mahul) {
+        this.type= type;
+        this.consonants = consonants;
+        this.mahul = mahul;
+    }
+    get_content() {
+        return this.consonants.join("") + this.mahul.get_content();
+    }
+}
+
+const build_consonants = (letters: Alphabet_char[]):
+{ consonants: Consonant[], remaining_letters: Alphabet_char[] } =>
+{
+    const consonants: Consonant[] = [];
+    let index = 0;
+    while (true) {
+        const letter = letters[index];
+        if (!is_consonant(letter)) {
+            break;
+        }
+        consonants.push(letter);
+        index++;
+    }
+    return { consonants, remaining_letters: letters.slice(index) };
+}
+
+const get_shyllable_type = (consonants: Consonant[]): Shyllable_Type | null => {
+    if (consonants.length === 1) {
+        if (is_sonorant(consonants[0])) {
+            return "sonorant-shyllable";
+        } else {
+            return "non-sonorant-shyllable";
+        }
+    }
+    return null;
+}
+
+function build_shyllable(letters: Alphabet_char[]):
+{ shyllable: Shyllable, unbuilt: Alphabet_char[] }
+{
+    const { consonants, remaining_letters } = build_consonants(letters);
+    const shyllable_type = get_shyllable_type(consonants);
+    if (shyllable_type === null) {
+        // todo error handling
+        const shyllable = new Shyllable("non-sonorant-shyllable", [], new Mahul([]));
+        return { shyllable, unbuilt: [] }; 
+    }
+    const { mahul, unbuilt } = build_mahul(remaining_letters); // todo error handling from here
+    const shyllable = new Shyllable(shyllable_type, consonants, mahul);
+    return { shyllable, unbuilt };
+}
+
+
+
+
+/* ENTRY */
+export default function build_combo(possible_word: Alphabet_char[]): Combo_Item[] {
+    const combo: Combo_Item[] = [];
+    let remaining_letters = possible_word;
+    while (remaining_letters.length > 0) {
+        const head = remaining_letters[0];
+        if (is_vowel(head)) {
+            const { mahul, unbuilt } = build_mahul(remaining_letters);
+            // todo error handling
+            combo.push(mahul);
+            remaining_letters = unbuilt;
+        } else if (is_consonant(head)) {
+            if (is_sonorant(head) && remaining_letters.length === 1) {
+                const sonorant = build_sonorant(head);
+                combo.push(sonorant);
+                remaining_letters = [];
+            } else {
+                const { shyllable, unbuilt } = build_shyllable(remaining_letters);
+                // todo error handling
+                combo.push(shyllable);
+                remaining_letters = unbuilt;
+            }
+        } else {
+            ; // TODO error handling, beginning with h or something else
+        }
+    }
+    return combo;
+}

--- a/web/src/scripts/lexer/index.ts
+++ b/web/src/scripts/lexer/index.ts
@@ -1,15 +1,10 @@
-const is_alphabetical = (char: string): boolean => {
-    return char === "some alphabet char";
-}
-
-const is_repeat = (char: string, last_char: string): boolean => {
-    const both_are_identical = char === last_char;
-    const both_are_spaces = [
-        char !== "" && last_char !== "",
-        !is_alphabetical(char) && !is_alphabetical(last_char),
-    ].every((bool) => bool);
-    return both_are_identical || both_are_spaces;
-}
+import {
+    Alphabet_char,
+    is_alphabetical,
+    is_repeat,
+} from "./types_and_preds";
+import build_combo from "./combo";
+import { any_number_of, begin, end, non_capturing_group, one_or_more, optional } from "../regex";
 
 interface Lexeme {
     readonly type: string,
@@ -19,18 +14,55 @@ interface Lexeme {
 const SPACE: Lexeme = { type: "Space", value: "" };
 
 
+/* ENTRY */
 export default function lex(input: string): Lexeme[] {
     const lexemes: Lexeme[] = [];
+    let possible_word: Alphabet_char[] = [];
     let last_char = "";
     for (const char of input) {
         if (is_repeat(char, last_char)) {
             continue;
         } else if (is_alphabetical(char)) {
-            ;
+            possible_word.push(char);
         } else {
             lexemes.push(SPACE);
+            lexemes.push(...lex_possible_word(possible_word))
+            possible_word = [];
         }
         last_char = char;
     }
+    if (possible_word.length > 0) {
+        lexemes.push(...lex_possible_word(possible_word))
+    }
     return lexemes;
 };
+
+
+function lex_possible_word(possible_word: Alphabet_char[]): Lexeme[] {
+    const lexemes: Lexeme[] = [];
+    // A word is lexed into a lexeme if it matches one of its combos.
+    const particle_combos = [
+        "non-sonorant-shyllable",
+        (
+            "mahul" +
+            any_number_of(non_capturing_group("sonorant-shyllable")) +
+            optional(non_capturing_group("sonorant"))
+        ),
+        (
+            one_or_more(non_capturing_group("sonorant-shyllable")) +
+            optional(non_capturing_group("sonorant"))
+        ),
+    ]
+    const possible_word_combo = build_combo(possible_word);
+    const combo_string = possible_word_combo.map((c) => c.type).join("");
+    for (const regex_string of particle_combos) {
+        const regex = new RegExp(begin + regex_string + end);
+        if (regex.test(combo_string)) {
+            lexemes.push({ 
+                type: "Particle",
+                value: possible_word_combo.map((c) => c.get_content()).join(""),
+            });
+        }
+    }
+    return lexemes;
+}

--- a/web/src/scripts/lexer/index.ts
+++ b/web/src/scripts/lexer/index.ts
@@ -1,8 +1,33 @@
+const is_alphabetical = (char: string): boolean => {
+    return char === "some alphabet char";
+}
+
+const is_repeat = (char: string, last_char: string): boolean => {
+    const both_are_identical = char === last_char;
+    const both_are_spaces = [
+        char !== "" && last_char !== "",
+        !is_alphabetical(char) && !is_alphabetical(last_char),
+    ].every((bool) => bool);
+    return both_are_identical || both_are_spaces;
+}
+
 interface Lexeme {
     readonly type: string,
     readonly value: string,
 };
 
-export default function lex(_: string): Lexeme[] {
-    return [];
-}
+export default function lex(input: string): Lexeme[] {
+    const lexemes: Lexeme[] = [];
+    let last_char = "";
+    for (const char of input) {
+        if (is_repeat(char, last_char)) {
+            continue;
+        } else if (is_alphabetical(char)) {
+            ;
+        } else {
+            lexemes.push({ type: "Space", value: "" });
+        }
+        last_char = char;
+    }
+    return lexemes;
+};

--- a/web/src/scripts/lexer/index.ts
+++ b/web/src/scripts/lexer/index.ts
@@ -16,6 +16,9 @@ interface Lexeme {
     readonly value: string,
 };
 
+const SPACE: Lexeme = { type: "Space", value: "" };
+
+
 export default function lex(input: string): Lexeme[] {
     const lexemes: Lexeme[] = [];
     let last_char = "";
@@ -25,7 +28,7 @@ export default function lex(input: string): Lexeme[] {
         } else if (is_alphabetical(char)) {
             ;
         } else {
-            lexemes.push({ type: "Space", value: "" });
+            lexemes.push(SPACE);
         }
         last_char = char;
     }

--- a/web/src/scripts/lexer/lexer.test.ts
+++ b/web/src/scripts/lexer/lexer.test.ts
@@ -7,7 +7,7 @@ test(`A string is not lexed if it is empty`, () => {
 })
 
 
-describe.skip(`A single eberban space is lexed if the inputted string`, () => {
+describe(`A single eberban space is lexed if the inputted string`, () => {
     describe(`comprises a single eberban space`, () => {
         test.for([
             `q`, `w`, `x`, `y`,

--- a/web/src/scripts/lexer/lexer.test.ts
+++ b/web/src/scripts/lexer/lexer.test.ts
@@ -86,9 +86,9 @@ describe(`A single eberban space is lexed if the inputted string`, () => {
 */
 
 
-describe.skip(`An eberban particle is lexed if it`, () => {
+describe(`An eberban particle is lexed if it`, () => {
     describe(`comprises a single non-sonorant-shyllable`, () => {
-        test.for([`zi`, `mio`, `tiho`, `saeoi`])(`%s`, (input) => {
+        test.for([`zi`, `mio`, `tiho`, `saeoi`, `paoieheha`])(`%s`, (input) => {
             expect(lex(input)).toStrictEqual([{ type: `Particle`, value: input }]);
         });
     });
@@ -98,7 +98,7 @@ describe.skip(`An eberban particle is lexed if it`, () => {
         3. optionally ends with a sonorant
         `,
         () => {
-            test.for([`a`, `ahu`, `al`, `anu`, `oie`, `oiu`])(`%s`, (input) => {
+            test.for([`a`, `ahu`, `al`, `anu`, `oie`, `oiu`, `uhieaho`])(`%s`, (input) => {
                 expect(lex(input)).toStrictEqual([{ type: `Particle`, value: input }]);
             });
         },
@@ -108,7 +108,7 @@ describe.skip(`An eberban particle is lexed if it`, () => {
         2. optionally ends with a sonorant
         `,
         () => {
-            test.for([`ni`, `ra`, `lu`, `nahinel`, `lulu`])(`%s`, (input) => {
+            test.for([`ni`, `ra`, `lu`, `nahinel`, `rihihihe`, `lulu`])(`%s`, (input) => {
                 expect(lex(input)).toStrictEqual([{ type: `Particle`, value: input }]);
             });
         },

--- a/web/src/scripts/lexer/types_and_preds.ts
+++ b/web/src/scripts/lexer/types_and_preds.ts
@@ -1,0 +1,41 @@
+import { all_non_sonorants, all_sonorants, all_vowels } from "../eberban_symbols";
+
+export type Sonorant = typeof all_sonorants[number];
+
+export type Consonant = typeof all_non_sonorants[number] | Sonorant;
+
+export type Vowel = typeof all_vowels[number];
+
+export type Alphabet_char = "h" | Consonant | Vowel;
+
+export const is_alphabetical = (char: string): char is Alphabet_char => {
+    const alphabet_array: string[] = [
+        "h",
+        ...all_non_sonorants.slice() as string[],
+        ...all_sonorants.slice() as string[],
+        ...all_vowels.slice() as string[],
+    ];
+    return alphabet_array.includes(char);
+}
+
+export const is_sonorant = (letter: Alphabet_char): letter is Sonorant => {
+    return (all_sonorants.slice() as Alphabet_char[]).includes(letter);
+}
+
+export const is_consonant = (letter: Alphabet_char): letter is Consonant => {
+    const is_non_sonorant = (all_non_sonorants.slice() as Alphabet_char[]).includes(letter);
+    return is_sonorant(letter) || is_non_sonorant;
+}
+
+export const is_repeat = (char: string, last_char: string): boolean => {
+    const both_are_identical = char === last_char;
+    const both_are_spaces = [
+        char !== "" && last_char !== "",
+        !is_alphabetical(char) && !is_alphabetical(last_char),
+    ].every((bool) => bool);
+    return both_are_identical || both_are_spaces;
+}
+
+export const is_vowel = (letter: Alphabet_char): letter is Vowel => {
+    return (all_vowels.slice() as Alphabet_char[]).includes(letter);
+}


### PR DESCRIPTION
This does not affect the website as the lexer remains unintegrated. This
PR [continues the test-driven implementation][tdd] of an Eberban lexer.

[tdd]:  https://github.com/eberban/eberban/pull/100

### New terms

> // A word is lexed into a lexeme if it matches one of its combos.
> — the code

A `combo` is made up of `combo_item`s which are either shyllables or
sonorants.

So, in a way, the lexer parses a combo into a lexeme. I found this
approach reduces regex usage and makes it easier to reason about where
lexing errors would pop up.
