### PR TITLE
👷 Create script+CI to check for unique dict IDs 

### DIFF
--- a/.github/workflows/check_word_ids.yml
+++ b/.github/workflows/check_word_ids.yml
@@ -1,0 +1,27 @@
+name: Check dictionary IDs are unique
+
+on:
+  push:
+    paths:
+      - dictionary/en.yaml
+  pull_request:
+    paths:
+      - dictionary/en.yaml   
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Install NPM dependencies for the dictionary scripts
+        run: |
+          cd dictionary
+          npm install
+          cd ..
+
+      - name: Check dictionary IDs are unique
+        run: |
+          node dictionary/check_word_ids.js dictionary/en.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Books.
 books/*/book
 
+# Dictionary
+dictionary/node_modules
+
 # Web.
 web/dist
 web/node_modules

--- a/dictionary/check_word_ids.js
+++ b/dictionary/check_word_ids.js
@@ -1,0 +1,67 @@
+if (process.argv.length != 3) {
+    console.log('usage : check_word_ids.js <file_path>');
+    console.log("Script will check all word ids in dictionary YAML file are unique.")
+    return;
+}
+
+const file_name = process.argv[2];
+
+const fs = require("fs");
+const YAML = require("yaml");
+
+const dictionary_file = fs.readFileSync(file_name, "utf8");
+const lineCounter = new YAML.LineCounter();
+const dictionary = YAML
+  .parseDocument(dictionary_file, { lineCounter })
+  .contents;
+
+const id_usages = new Map();
+
+YAML.visit(
+  dictionary,
+  {
+    Pair: (_, node, path) => {
+      if (node.key.value === "id") {
+        // path is structured like so:
+        // [YAMLMap, ancestor_node, YAMLMap, ancestor_node..., YAMLMap]
+        // so the parent node is second to last.
+        const word = path[path.length - 2].key.value;
+        const id = node.value.value;
+        const id_line_data = lineCounter.linePos(node.value.range[0]);
+        const id_line = id_line_data.line;
+        const id_col = id_line_data.col;
+        const id_end_column = id_line_data.col + (id.length - 1);
+
+        const usage = { word, id_line, id_col,id_end_column };
+
+        if (id_usages.has(id)) {
+          id_usages.get(id).push(usage);
+        } else {
+          id_usages.set(id, [usage]);
+        }
+      }
+    }
+  },
+);
+
+let duplicates_found = false;
+
+for (const [id, all_usages] of id_usages) {
+  if (all_usages.length > 1) {
+    all_usages.forEach(({ word, id_line, id_col, id_end_column }) => {
+      // Output GitHub Annotation error messages. These will show up in the PR
+      // diff.
+      console.log(`::error file=${file_name},line=${id_line},col=${id_col},endColumn=${id_end_column}::Duplicate ID ${id} in word ${word}`);
+    })
+    duplicates_found = true;
+  }
+}
+
+if (duplicates_found) {
+  console.log("❌ Duplicate IDs found.");
+  process.exit(1);
+}
+console.log("✅ All IDs are unique.");
+process.exit(0);
+
+

--- a/dictionary/en.yaml
+++ b/dictionary/en.yaml
@@ -50,7 +50,7 @@
   links:
     - ["icon-book", "Numbers - Digits", https://eberban.github.io/eberban/books/refgram/book/grammar/numbers.html#digits]
 5:
-  id: xlftdvdomw
+  id: jxgthvv20z
   family: "TI"
   gloss: "tie"
   tags: [number, digit, informal]
@@ -59,7 +59,7 @@
   links:
     - ["icon-book", "Numbers - Digits", https://eberban.github.io/eberban/books/refgram/book/grammar/numbers.html#digits]
 6:
-  id: 3xu1e18wct
+  id: clpqjeyf1b
   family: "TI"
   gloss: "tia"
   tags: [number, digit, informal]
@@ -150,7 +150,7 @@ mao:
   links:
     - ["icon-book", "Logical primitives", https://eberban.github.io/eberban/books/refgram/book/logic/primitives.html]
 mae:
-  id: xlftdvdomw
+  id: k9n5jsy7np
   family: "MI"
   gloss: "partial-appl:"
   tags: [core]
@@ -481,7 +481,7 @@ fie:
   links:
     - ["icon-book", "Explicit binding - Left predicate place selection", https://eberban.github.io/eberban/books/refgram/book/logic/explicit_binding.html#left-predicate-place-selection]
 fia:
-  id: v47til8m74
+  id: 0uktfjuhwa
   family: "FI"
   gloss: "]A=["
   tags: [core]
@@ -1016,7 +1016,7 @@ onu:
 #   links:
 #     - ["icon-book", "Sentences - A family", https://eberban.github.io/eberban/books/refgram/book/logic/sentences.html#a-family]
 an:
-  id: v47til8m74
+  id: zkukmnzdxs
   family: "A"
   gloss: "#update-context"
   tags: [core, context]
@@ -1324,7 +1324,7 @@ jei:
   links:
     - ["icon-book", "Numbers - Number syntax", https://eberban.github.io/eberban/books/refgram/book/grammar/numbers.html#number-syntax]
 ti:
-  id: 3xu1e18wct
+  id: ivcpysqf4j
   family: "TI"
   short: "Digit 0"
   gloss: "0"
@@ -1594,7 +1594,7 @@ al:
   links:
     - ["icon-book", "Sentences - A family", https://eberban.github.io/eberban/books/refgram/book/logic/sentences.html#a-family]
 o:
-  id: 3xu1e18wct
+  id: ici1wrui6g
   family: "O"
   gloss: "#question"
   short: "Start a question definition, the arguments being the unknown informations."
@@ -3933,7 +3933,7 @@ tsir:
   gloss: "bed"
   short: "[E:tce* pan] is a bed."
 gzian:
-  id: 3xu1e18wct
+  id: jhnc5nvbrz
   family: "R"
   gloss: "showers"
   short: "[E:tce* pan] showers in substance [A:tce pan] (default: water)."
@@ -6914,7 +6914,7 @@ _spelling:
     short: |
       {ce}: \\ (backslash) symbol.
   sla: 
-    id: 3xu1e18wct
+    id: iohrkvpgou
     gloss: "|"
     tags: ["symbol"]
     short: |
@@ -6932,7 +6932,7 @@ _spelling:
     short: |
       {ce}: ? (question mark) symbol.
   gli: 
-    id: 3xu1e18wct
+    id: nkbk8lcocf
     gloss: "UPPERCASE:"
     tags: ["case"]
     short: |

--- a/dictionary/en.yaml
+++ b/dictionary/en.yaml
@@ -3544,7 +3544,7 @@ dena:
     and we're not speaking about a specific day in the Gregorian calendar,
     [E] is a subset of all possible durations of a day.
 denai:
-  id: lvhzpvgj4z
+  id: hlxvt9w4ga
   family: "R"
   gloss: "day (event)"
   short: "Now is the day [E:tce gien] (default: 0) of [A:()] (default: {garei})."
@@ -3563,7 +3563,7 @@ sura:
     and we're not speaking about a specific hour in the Gregorian calendar,
     [E] is a subset of all possible durations of an hour.
 surai:
-  id: lvhzpvgj4z
+  id: csqvyaljot
   family: "R"
   gloss: "hour (event)"
   short: "Now is the hour [E:tce gien] of [A:()] (default: {denai})."
@@ -3578,7 +3578,7 @@ jero:
   short: "[E:tce gan] is 1 minute times [A:tce gan] (default: 1)."
   tags: [time, unit, minute]
 jeroi:
-  id: lvhzpvgj4z
+  id: l5u3vuf9yc
   family: "R"
   gloss: "minute (event)"
   short: "Now is the minute [E:tce gien] of [A:()] (default: {surai})"
@@ -6462,7 +6462,7 @@ e kine ctal:
   gloss: "school"
   short: "[E:tce* pan] is a school/educational building."
 e spua ctal:
-  id: wlqy92kdaz
+  id: urxuw8ethp
   predilex_id: detume
   family: "C"
   gloss: "residential building"

--- a/dictionary/en.yaml
+++ b/dictionary/en.yaml
@@ -50,7 +50,7 @@
   links:
     - ["icon-book", "Numbers - Digits", https://eberban.github.io/eberban/books/refgram/book/grammar/numbers.html#digits]
 5:
-  id: jxgthvv20z
+  id: xlftdvdomw
   family: "TI"
   gloss: "tie"
   tags: [number, digit, informal]
@@ -59,7 +59,7 @@
   links:
     - ["icon-book", "Numbers - Digits", https://eberban.github.io/eberban/books/refgram/book/grammar/numbers.html#digits]
 6:
-  id: clpqjeyf1b
+  id: 3xu1e18wct
   family: "TI"
   gloss: "tia"
   tags: [number, digit, informal]
@@ -150,7 +150,7 @@ mao:
   links:
     - ["icon-book", "Logical primitives", https://eberban.github.io/eberban/books/refgram/book/logic/primitives.html]
 mae:
-  id: k9n5jsy7np
+  id: xlftdvdomw
   family: "MI"
   gloss: "partial-appl:"
   tags: [core]
@@ -481,7 +481,7 @@ fie:
   links:
     - ["icon-book", "Explicit binding - Left predicate place selection", https://eberban.github.io/eberban/books/refgram/book/logic/explicit_binding.html#left-predicate-place-selection]
 fia:
-  id: 0uktfjuhwa
+  id: v47til8m74
   family: "FI"
   gloss: "]A=["
   tags: [core]
@@ -1016,7 +1016,7 @@ onu:
 #   links:
 #     - ["icon-book", "Sentences - A family", https://eberban.github.io/eberban/books/refgram/book/logic/sentences.html#a-family]
 an:
-  id: zkukmnzdxs
+  id: v47til8m74
   family: "A"
   gloss: "#update-context"
   tags: [core, context]
@@ -1324,7 +1324,7 @@ jei:
   links:
     - ["icon-book", "Numbers - Number syntax", https://eberban.github.io/eberban/books/refgram/book/grammar/numbers.html#number-syntax]
 ti:
-  id: ivcpysqf4j
+  id: 3xu1e18wct
   family: "TI"
   short: "Digit 0"
   gloss: "0"
@@ -1594,7 +1594,7 @@ al:
   links:
     - ["icon-book", "Sentences - A family", https://eberban.github.io/eberban/books/refgram/book/logic/sentences.html#a-family]
 o:
-  id: ici1wrui6g
+  id: 3xu1e18wct
   family: "O"
   gloss: "#question"
   short: "Start a question definition, the arguments being the unknown informations."
@@ -3933,7 +3933,7 @@ tsir:
   gloss: "bed"
   short: "[E:tce* pan] is a bed."
 gzian:
-  id: jhnc5nvbrz
+  id: 3xu1e18wct
   family: "R"
   gloss: "showers"
   short: "[E:tce* pan] showers in substance [A:tce pan] (default: water)."
@@ -6914,7 +6914,7 @@ _spelling:
     short: |
       {ce}: \\ (backslash) symbol.
   sla: 
-    id: iohrkvpgou
+    id: 3xu1e18wct
     gloss: "|"
     tags: ["symbol"]
     short: |
@@ -6932,7 +6932,7 @@ _spelling:
     short: |
       {ce}: ? (question mark) symbol.
   gli: 
-    id: nkbk8lcocf
+    id: 3xu1e18wct
     gloss: "UPPERCASE:"
     tags: ["case"]
     short: |

--- a/dictionary/en.yaml
+++ b/dictionary/en.yaml
@@ -1102,7 +1102,8 @@ bi:
   tags: [core, negation]
   short: "Wide scope negation ranging over existential variables and predicates."
   links:
-    - ["icon-book", "Predicate transformations - Negations", https://eberban.github.io/eberban/books/refgram/book/logic/transformations.html?highlight=bi#negations]
+    # Quoting the "?"-containing URL so check_word_ids.sh can parse this file
+    - ["icon-book", "Predicate transformations - Negations", "https://eberban.github.io/eberban/books/refgram/book/logic/transformations.html?highlight=bi#negations"] 
 bo:
   id: 9eludeaq4v
   family: "BO"

--- a/dictionary/package-lock.json
+++ b/dictionary/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "dictionary",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    }
+  }
+}

--- a/dictionary/package.json
+++ b/dictionary/package.json
@@ -1,5 +1,9 @@
 {
   "scripts": {
-    "ids": "node ./generate_word_ids ./en.yaml"
+    "ids": "node ./generate_word_ids ./en.yaml",
+    "check-ids": "node ./check_word_ids ./en.yaml"
+  },
+  "dependencies": {
+    "yaml": "^2.8.1"
   }
 }


### PR DESCRIPTION
Contributors to the repository will now be able to locally check
dictionary IDs are unique and any pushes and PRs will fail if all
dictionary IDs (in dictionary/en.yaml) are not unique.

With this change we'll be able to rely on each dictionary ID being
unique.

I tried implementing this with mikefarah's yq, however it does not
retain line numbers upon parsing. The "line" command of yq points to a
node position, not a file line number.