### PR TITLE
🐛 Fix dict backslashes not being replaced by newlines

### DIFF
--- a/web/src/dictionary/markup/kits.tsx
+++ b/web/src/dictionary/markup/kits.tsx
@@ -36,22 +36,22 @@ type Kit = {
     replacer: Replacer,
 }
 
-// We're using preact-parser which suits our needs nearly perfectly. It's just
-// that single newlines are swallowed by default. So instead, we're replacing
-// them with spaces until this gets fixed:
-// https://github.com/jahilldev/preact-parser/issues
-function new_line_to_space_kit(): Kit {
-    return {
-        regex_string: group(line_feed),
-        replacer: () => <>{" "}</>,
-    }
-}
-
 function break_kit(): Kit {
     return {
         regex_string: group(backslash + line_feed),
         replacer: () => <br />,
     };
+}
+
+// We're using preact-parser which suits our needs nearly perfectly. It's just
+// that single newlines are swallowed by default. So instead, we're replacing
+// them with spaces until this gets fixed:
+// https://github.com/jahilldev/preact-parser/issues/7
+function new_line_to_space_kit(): Kit {
+    return {
+        regex_string: group(line_feed),
+        replacer: () => <>{" "}</>,
+    }
 }
 
 function bold_kit(): Kit {
@@ -142,8 +142,8 @@ function place_kit(): Kit {
 
 
 const markup_kits = [
-        new_line_to_space_kit,
         break_kit,
+        new_line_to_space_kit,
         bold_kit,
         italics_kit,
         definition_quote_kit,


### PR DESCRIPTION
Now in the dictionary, viewers will see newlines instead of `\`s.

---

**Why was this happening to begin with?**

https://github.com/eberban/eberban/blob/ecab36278d0a9e53f5911389aee9c63f8fde45b4/web/src/dictionary/markup/kits.tsx#L144-L153

https://github.com/eberban/eberban/blob/ecab36278d0a9e53f5911389aee9c63f8fde45b4/web/src/dictionary/markup/kits.tsx#L43-L55

Before the fix, the `new_line_to_space_kit` ran before the `break_kit`,
changing all newlines to spaces.

Before the fix, `break_kit` was trying to match backslash and a line
feed (i.e., any indication of a newline). It could not, however, find a
line feed after a backslash, and thus no replacements were made.