### PR TITLE
🐛 Fix broken eberban quote links

### DIFF
--- a/dictionary/en.yaml
+++ b/dictionary/en.yaml
@@ -2790,7 +2790,7 @@ pure:
   family: "R"
   gloss: "hears"
   short: "[E:tce* pan] hears [A:tce* man]."
-  notes: For listening see {etripure}.
+  notes: For listening see {etaripure}.
 vain:
   id: ndedgziytg
   predilex_id: yogije

--- a/web/src/dictionary/markup/kits.tsx
+++ b/web/src/dictionary/markup/kits.tsx
@@ -82,11 +82,11 @@ function definition_quote_kit(): Kit {
 function eberban_quote_kit(): Kit {
     const in_quote = (s: string) => "{" + s + "}";
     return {
-        keep_children_as_string: true,
         regex_string: in_quote(group(fewest_positive_number_of(any))),
         replacer: (content) => {
-            const { regex_string, replacer } = content_kit();
-            let rendered_content = markup_to_jsx_child(content as string, regex_string, replacer);
+            const { regex_string, replacer, keep_children_as_string } = content_kit();
+            let rendered_content = markup_to_jsx_child(
+                content as string, regex_string, replacer, keep_children_as_string);
             rendered_content = markup_to_jsx_child(rendered_content, "!", () => <></>);
             return <span class="ebb-quote">{rendered_content}</span>;
         },  
@@ -103,6 +103,7 @@ function eberban_quote_kit(): Kit {
             ))
         ));
         return {
+            keep_children_as_string: true,
             regex_string: any_of(simple_word_link, compound_word_link),
             replacer: (simple_word_link, compound_word_link) => {
             // Only one of these will be defined.


### PR DESCRIPTION
The `<a href=`s on eberban quotes were rendering as `#[object Object]`.

Clicking on these links will now load the corresponding dictionary entry.

**Why was this broken?**

By default, converting an object to a string returns `[object Object]`.

This string conversion happens in the `<a href=` of the `<DictLink`
component via JavaScript's template literal syntax. This is why the text
of the link was rendering fine, but the link itself was broken.

The fix was to keep the children of the eberban quote content as string,
so that no object to string conversion happens.