### PR TITLE
🐛 Fix broken eberban slot links

### DIFF
--- a/web/src/dictionary/markup/kits.tsx
+++ b/web/src/dictionary/markup/kits.tsx
@@ -121,9 +121,10 @@ function place_kit(): Kit {
     return {
         regex_string: in_brackets(place + optional(arg)),
         replacer: (place, arg) => {
-            const { regex_string, replacer } = arg_kit();
+            const { regex_string, replacer, keep_children_as_string } = arg_kit();
             // Sometimes there is no arg.
-            const arg_with_links = markup_to_jsx_child(arg ?? "", regex_string, replacer);
+            const arg_with_links = markup_to_jsx_child(
+                arg ?? "", regex_string, replacer, keep_children_as_string);
             return (
                 <span class="label label-info place">
                     <span class="hidden">{"["}</span>
@@ -135,6 +136,7 @@ function place_kit(): Kit {
     }
     function arg_kit(): Kit {
         return {
+            keep_children_as_string: true,
             regex_string: group(word_char + one_or_more(word_char)),
             replacer: (s) => <DictLink>{s as string}</DictLink>,
         };


### PR DESCRIPTION
The `<a href=`s on eberban slots were rendering as `#[object Object]`.

Clicking on these links will now load the corresponding dictionary entry.

**Why was this broken?**

Please see either:

- https://github.com/eberban/eberban/pull/121
- be436fc5bf525ffc82fd8f7bfb18b304548430d1

For the same problem (except with eberban quotes) and the same fix.