### PR TITLE
🚸 Make dict ID searches only return exact matches

### DIFF
--- a/web/src/dictionary/dictionary.jsx
+++ b/web/src/dictionary/dictionary.jsx
@@ -180,7 +180,7 @@ function may_insert_entry(results, filters, word, entry) {
 					entry.without_spaces.includes(filter) ||
 					entry.gloss?.toLowerCase().includes(filter) ||
 					entry.short?.toLowerCase().includes(filter) ||
-					entry.id?.toLowerCase().includes(filter) ||
+					entry.id.toLowerCase() == filter ||
 					entry.notes?.toLowerCase().includes(filter)
 				)
 			) {


### PR DESCRIPTION
As requested in the Discord.

And because we now ensure every word has an ID (see below PR) I've removed the optional chaining.